### PR TITLE
[DEVELOP-1137-2] Raise extension events for Gitlab

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,29 @@
           "entryPoint": "src/webhooks/webhook.ts",
           "public": true
         }
+      },
+      "automationTriggers": {
+        "draftPrOpened": {
+          "title": "Draft PR opened"
+        },
+        "prOpened": {
+          "title": "PR opened"
+        },
+        "prMerged": {
+          "title": "PR merged"
+        },
+        "prClosed": {
+          "title": "PR closed"
+        },
+        "prReopened": {
+          "title": "PR reopened"
+        },
+        "prApproved": {
+          "title": "PR approved"
+        },
+        "prChangesRequested": {
+          "title": "PR changes requested"
+        }
       }
     }
   },

--- a/src/types/gitlab.d.ts
+++ b/src/types/gitlab.d.ts
@@ -5,7 +5,7 @@ declare namespace Gitlab {
 
   type MergeRequestState = 'all' | 'closed' | 'locked' | 'merged' | 'opened';
 
-  type MergeRequestAction = 'open' | 'close' | 'reopen' | 'update' | 'approved' | 'unapproved' | 'approval' | 'unapproval' | 'merge;'
+  type MergeRequestAction = 'open' | 'close' | 'reopen' | 'update' | 'approved' | 'unapproved' | 'approval' | 'unapproval' | 'merge';
 
   interface Connections<T> {
     count?: number;

--- a/src/types/gitlab.d.ts
+++ b/src/types/gitlab.d.ts
@@ -5,6 +5,8 @@ declare namespace Gitlab {
 
   type MergeRequestState = 'all' | 'closed' | 'locked' | 'merged' | 'opened';
 
+  type MergeRequestAction = 'open' | 'close' | 'reopen' | 'update' | 'approved' | 'unapproved' | 'approval' | 'unapproval' | 'merge;'
+
   interface Connections<T> {
     count?: number;
     edges?: Edge<T>[];

--- a/src/types/webhook.d.ts
+++ b/src/types/webhook.d.ts
@@ -55,6 +55,7 @@ declare namespace Webhook {
     iid?: number;
     url?: string;
     state?: Gitlab.MergeRequestState;
+    action?: Gitlab.MergeRequestAction;
     title?: string;
     source?: Project;
     target?: Project;
@@ -64,5 +65,6 @@ declare namespace Webhook {
     merge_status: Gitlab.MergeStatus;
     source_branch?: string;
     target_branch?: string;
+    work_in_progress?: boolean;
   }
 }

--- a/src/webhooks/webhook.ts
+++ b/src/webhooks/webhook.ts
@@ -80,7 +80,7 @@ async function triggerAutomation(payload: Webhook.Payload, record) {
   }
 
   const triggers: Record<string, (pr: any) => string> = {
-    open: (pr) => pr.work_in_progress ? "draftPROpened" : "prOpened",
+    open: (pr) => pr.work_in_progress ? "draftPrOpened" : "prOpened",
     close: () => "prClosed",
     reopen: () => "prReopened",
     merge: () => "prMerged",

--- a/src/webhooks/webhook.ts
+++ b/src/webhooks/webhook.ts
@@ -1,3 +1,4 @@
+import { IDENTIFIER } from '@lib/extension.js';
 import { runCommand } from '@lib/runCommand.js';
 import { linkMergeRequest, linkBranch, referenceToRecordFromTitle, linkMergeRequestToRecord } from '../lib/fields.js';
 
@@ -42,6 +43,7 @@ const handleMergeRequest = async (payload: Webhook.Payload) => {
   // Link MR to record
   await linkMergeRequestToRecord(mr, record);
   await triggerEvent('mr.update', payload, record);
+  await triggerAutomation(payload, record)
 };
 
 async function handleCreateBranch(payload: Webhook.Payload) {
@@ -57,6 +59,50 @@ async function handleCreateBranch(payload: Webhook.Payload) {
 
     const record = await linkBranch(branchName, payload?.repository?.homepage ?? '');
     await triggerEvent('branch.create', payload, record);
+  }
+}
+
+/**
+ * Trigger an automation
+ *
+ * @param payload
+ * @param record
+ */
+async function triggerAutomation(payload: Webhook.Payload, record) {
+  if (payload?.event_type !== "merge_request") return;
+
+  const { object_attributes } = payload
+  if (!object_attributes) return;
+
+  // Check the record is a supported type
+  if (!["Epic", "Feature", "Requirement"].includes(record.typename)) {
+    return;
+  }
+
+  const triggers: Record<string, (pr: any) => string> = {
+    open: (pr) => pr.work_in_progress ? "draftPROpened" : "prOpened",
+    close: () => "prClosed",
+    reopen: () => "prReopened",
+    merge: () => "prMerged",
+    approved: () => "prApproved",
+    unapproval: () => "prChangesRequested"
+  };
+
+  const { action } = object_attributes
+  if (!action) return
+
+  const trigger = (triggers[action] || (() => null))(
+    payload.object_attributes
+  );
+
+  console.log(`Triggering ${trigger} automation on ${record.referenceNumber}`)
+
+  if (trigger) {
+    await aha.triggerAutomationOn(
+      record,
+      [IDENTIFIER, trigger].join("."),
+      true
+    );
   }
 }
 

--- a/src/webhooks/webhook.ts
+++ b/src/webhooks/webhook.ts
@@ -40,8 +40,11 @@ const handleMergeRequest = async (payload: Webhook.Payload) => {
   // Make sure the MR is linked to its record.
   const record = await linkMergeRequest(mr);
 
+  if (!record) {
+    return null;
+  }
+
   // Link MR to record
-  await linkMergeRequestToRecord(mr, record);
   await triggerEvent('mr.update', payload, record);
   await triggerAutomation(payload, record)
 };


### PR DESCRIPTION
GitLab's webhook data makes this pretty straight-forward.

One challenge is that they have an additional "update" action for Merge Requests. When an open MR is moved to draft status, the "update" event is fired instead of the "open" event. I could use that to fire the "prOpened" and "draftPrOpened" triggers, but I'm not sure what other conditions trigger the `update` event. We may end up accidentally moving records between statuses in unexpected ways (e.g. updating the description after the PR is approved could punt it back to in progress).

What do you think @percyhanna?